### PR TITLE
Change tf.types.int16 to tf.int16

### DIFF
--- a/deep-learning/tensor-flow-examples/notebooks/1_intro/basic_operations.ipynb
+++ b/deep-learning/tensor-flow-examples/notebooks/1_intro/basic_operations.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -68,7 +68,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -76,8 +76,8 @@
     "# The value returned by the constructor represents the output\n",
     "# of the Variable op. (define as input when running session)\n",
     "# tf Graph input\n",
-    "a = tf.placeholder(tf.types.int16)\n",
-    "b = tf.placeholder(tf.types.int16)"
+    "a = tf.placeholder(tf.int16)\n",
+    "b = tf.placeholder(tf.int16)"
    ]
   },
   {
@@ -194,25 +194,34 @@
     "    result = sess.run(product)\n",
     "    print result"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.5+"
   }
  },
  "nbformat": 4,

--- a/deep-learning/tensor-flow-examples/notebooks/3_neural_networks/alexnet.ipynb
+++ b/deep-learning/tensor-flow-examples/notebooks/3_neural_networks/alexnet.ipynb
@@ -86,9 +86,9 @@
    "outputs": [],
    "source": [
     "# tf Graph input\n",
-    "x = tf.placeholder(tf.types.float32, [None, n_input])\n",
-    "y = tf.placeholder(tf.types.float32, [None, n_classes])\n",
-    "keep_prob = tf.placeholder(tf.types.float32) # dropout (keep probability)"
+    "x = tf.placeholder(tf.float32, [None, n_input])\n",
+    "y = tf.placeholder(tf.float32, [None, n_classes])\n",
+    "keep_prob = tf.placeholder(tf.float32) # dropout (keep probability)"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "source": [
     "# Evaluate model\n",
     "correct_pred = tf.equal(tf.argmax(pred,1), tf.argmax(y,1))\n",
-    "accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.types.float32))"
+    "accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.float32))"
    ]
   },
   {
@@ -323,21 +323,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.5+"
   }
  },
  "nbformat": 4,

--- a/deep-learning/tensor-flow-examples/notebooks/3_neural_networks/convolutional_network.ipynb
+++ b/deep-learning/tensor-flow-examples/notebooks/3_neural_networks/convolutional_network.ipynb
@@ -86,9 +86,9 @@
    "outputs": [],
    "source": [
     "# tf Graph input\n",
-    "x = tf.placeholder(tf.types.float32, [None, n_input])\n",
-    "y = tf.placeholder(tf.types.float32, [None, n_classes])\n",
-    "keep_prob = tf.placeholder(tf.types.float32) #dropout (keep probability)"
+    "x = tf.placeholder(tf.float32, [None, n_input])\n",
+    "y = tf.placeholder(tf.float32, [None, n_classes])\n",
+    "keep_prob = tf.placeholder(tf.float32) #dropout (keep probability)"
    ]
   },
   {
@@ -201,7 +201,7 @@
    "source": [
     "# Evaluate model\n",
     "correct_pred = tf.equal(tf.argmax(pred,1), tf.argmax(y,1))\n",
-    "accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.types.float32))"
+    "accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.float32))"
    ]
   },
   {
@@ -299,21 +299,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.5+"
   }
  },
  "nbformat": 4,

--- a/deep-learning/tensor-flow-examples/notebooks/3_neural_networks/recurrent_network.ipynb
+++ b/deep-learning/tensor-flow-examples/notebooks/3_neural_networks/recurrent_network.ipynb
@@ -137,7 +137,7 @@
     "\n",
     "# Evaluate model\n",
     "correct_pred = tf.equal(tf.argmax(pred,1), tf.argmax(y,1))\n",
-    "accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.types.float32))"
+    "accuracy = tf.reduce_mean(tf.cast(correct_pred, tf.float32))"
    ]
   },
   {
@@ -272,21 +272,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.5+"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I was learning Tensorflow using this notebook and got AttributeError while running

```
a = tf.placeholder(tf.types.int16)
```

In [docs] (https://www.tensorflow.org/versions/master/api_docs/python/framework.html#DType), it is written as `tf.int16` instead of `tf.types.int16` and it works on my machine too. 
Let me know if I'm missing something?