### PR TITLE
Fixed ambiguous output and replaced deprecated functions

### DIFF
--- a/pandas/pandas.ipynb
+++ b/pandas/pandas.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -78,7 +78,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -108,7 +108,7 @@
        "array([ 1,  1,  2, -3, -5,  8, 13])"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -139,7 +139,7 @@
        "Int64Index([0, 1, 2, 3, 4, 5, 6], dtype='int64')"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -173,7 +173,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -203,7 +203,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -235,7 +235,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
@@ -267,7 +267,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -301,7 +301,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -335,7 +335,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -370,7 +370,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -405,7 +405,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -425,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
@@ -440,7 +440,7 @@
        "dtype: bool"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -458,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -473,7 +473,7 @@
        "dtype: bool"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -491,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -506,7 +506,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -524,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
@@ -542,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -553,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false
    },
@@ -562,14 +562,14 @@
      "data": {
       "text/plain": [
        "label\n",
-       "foo      100\n",
-       "bar      200\n",
-       "baz      300\n",
-       "qux      NaN\n",
+       "foo    100\n",
+       "bar    200\n",
+       "baz    300\n",
+       "qux    NaN\n",
        "Name: foobarbazqux, dtype: float64"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -587,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -602,7 +602,7 @@
        "Name: foobarbazqux, dtype: float64"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -625,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false
    },
@@ -633,7 +633,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -646,33 +646,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -687,7 +687,7 @@
        "4  4.1    MD  2015"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -709,7 +709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 33,
    "metadata": {
     "collapsed": false
    },
@@ -717,7 +717,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -730,33 +730,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -771,7 +771,7 @@
        "4  2015    MD  4.1"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -790,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false
    },
@@ -798,7 +798,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -812,38 +812,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -858,7 +858,7 @@
        "4  2015    MD  4.1    NaN"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -877,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 35,
    "metadata": {
     "collapsed": false
    },
@@ -893,7 +893,7 @@
        "Name: state, dtype: object"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -911,7 +911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 36,
    "metadata": {
     "collapsed": false
    },
@@ -927,7 +927,7 @@
        "Name: year, dtype: int64"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -945,7 +945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 37,
    "metadata": {
     "collapsed": false
    },
@@ -960,7 +960,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -978,7 +978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 38,
    "metadata": {
     "collapsed": false
    },
@@ -986,7 +986,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1000,38 +1000,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> 0</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> 1</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 2</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 3</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 4</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>4</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1046,7 +1046,7 @@
        "4  2015    MD  4.1       4"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1065,7 +1065,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 39,
    "metadata": {
     "collapsed": false
    },
@@ -1073,7 +1073,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1087,38 +1087,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1133,7 +1133,7 @@
        "4  2015    MD  4.1     6.1"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1153,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 40,
    "metadata": {
     "collapsed": false
    },
@@ -1161,7 +1161,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1176,43 +1176,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> VA</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>VA</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> VA</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>VA</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> VA</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>VA</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> MD</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>MD</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> MD</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>MD</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1227,7 +1227,7 @@
        "4  2015    MD  4.1     6.1        MD"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1246,7 +1246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 41,
    "metadata": {
     "collapsed": false
    },
@@ -1254,7 +1254,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1268,38 +1268,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1314,7 +1314,7 @@
        "4  2015    MD  4.1     6.1"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1333,7 +1333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 42,
    "metadata": {
     "collapsed": false
    },
@@ -1341,7 +1341,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1353,18 +1353,18 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2013</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>5.1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2014</th>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 5.2</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>5.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2015</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1377,7 +1377,7 @@
        "2015  4.1  NaN"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1398,7 +1398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 43,
    "metadata": {
     "collapsed": false
    },
@@ -1406,7 +1406,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1419,15 +1419,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>MD</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 4.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>4.1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>VA</th>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1439,7 +1439,7 @@
        "VA   5.1   5.2   NaN"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1457,7 +1457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 44,
    "metadata": {
     "collapsed": false
    },
@@ -1465,7 +1465,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1477,13 +1477,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2014</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 5.2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>5.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2015</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1495,7 +1495,7 @@
        "2015  4.1  NaN"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1516,7 +1516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 45,
    "metadata": {
     "collapsed": false
    },
@@ -1524,7 +1524,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1541,13 +1541,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2014</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 5.2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>5.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2015</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1560,7 +1560,7 @@
        "2015  4.1  NaN"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1579,7 +1579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 46,
    "metadata": {
     "collapsed": false
    },
@@ -1587,7 +1587,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1604,13 +1604,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2014</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 5.2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>5.2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2015</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1623,7 +1623,7 @@
        "2015   4.1  NaN"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1642,7 +1642,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 47,
    "metadata": {
     "collapsed": false
    },
@@ -1654,7 +1654,7 @@
        "       [ 4.1,  nan]])"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1672,7 +1672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 48,
    "metadata": {
     "collapsed": false
    },
@@ -1687,7 +1687,7 @@
        "       [2015, 'MD', 4.1, 6.1]], dtype=object)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1712,7 +1712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 49,
    "metadata": {
     "collapsed": false
    },
@@ -1720,7 +1720,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1734,38 +1734,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1780,7 +1780,7 @@
        "4  2015    MD  4.1     6.1"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1798,7 +1798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 50,
    "metadata": {
     "collapsed": false
    },
@@ -1806,7 +1806,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1820,45 +1820,45 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>  NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2015</td>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2014</td>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 2013</td>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 2012</td>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1874,7 +1874,7 @@
        "0  2012    VA  5.0     NaN"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1892,7 +1892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 51,
    "metadata": {
     "collapsed": false
    },
@@ -1900,7 +1900,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1922,7 +1922,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1940,7 +1940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 52,
    "metadata": {
     "collapsed": false
    },
@@ -1951,7 +1951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 53,
    "metadata": {
     "collapsed": false
    },
@@ -1967,7 +1967,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1978,7 +1978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 54,
    "metadata": {
     "collapsed": false
    },
@@ -1994,7 +1994,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2012,7 +2012,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 55,
    "metadata": {
     "collapsed": false
    },
@@ -2020,7 +2020,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2034,38 +2034,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2080,7 +2080,7 @@
        "4    MD  4.1     6.1  2015"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2098,7 +2098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 56,
    "metadata": {
     "collapsed": false
    },
@@ -2106,7 +2106,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2120,45 +2120,45 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>  0</td>\n",
-       "      <td> 0.0</td>\n",
-       "      <td> 0.0</td>\n",
-       "      <td>    0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2174,7 +2174,7 @@
        "0    VA  5.0     NaN  2012"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2194,7 +2194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 57,
    "metadata": {
     "collapsed": false
    },
@@ -2202,7 +2202,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2216,52 +2216,52 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2278,7 +2278,7 @@
        "6   NaN  NaN     NaN   NaN"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2304,7 +2304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 58,
    "metadata": {
     "collapsed": false
    },
@@ -2312,7 +2312,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2326,38 +2326,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2372,7 +2372,7 @@
        "6   NaN  NaN     NaN   NaN"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2391,7 +2391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 59,
    "metadata": {
     "collapsed": false
    },
@@ -2399,7 +2399,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2412,33 +2412,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2453,7 +2453,7 @@
        "6   NaN  NaN   NaN"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2479,7 +2479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 60,
    "metadata": {
     "collapsed": false
    },
@@ -2495,7 +2495,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2513,7 +2513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 61,
    "metadata": {
     "collapsed": false
    },
@@ -2524,7 +2524,7 @@
        "True"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2542,7 +2542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 62,
    "metadata": {
     "collapsed": false
    },
@@ -2556,7 +2556,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2574,7 +2574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 63,
    "metadata": {
     "collapsed": false
    },
@@ -2588,7 +2588,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2606,7 +2606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 64,
    "metadata": {
     "collapsed": false
    },
@@ -2620,7 +2620,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2638,7 +2638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 65,
    "metadata": {
     "collapsed": false
    },
@@ -2651,7 +2651,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2669,7 +2669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 66,
    "metadata": {
     "collapsed": false
    },
@@ -2685,7 +2685,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2704,7 +2704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 67,
    "metadata": {
     "collapsed": false
    },
@@ -2712,7 +2712,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2726,52 +2726,52 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2788,7 +2788,7 @@
        "6   NaN  NaN     NaN   NaN"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2806,7 +2806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 68,
    "metadata": {
     "collapsed": false
    },
@@ -2814,7 +2814,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2826,38 +2826,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2874,7 +2874,7 @@
        "6  NaN     NaN"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2892,7 +2892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 69,
    "metadata": {
     "collapsed": false
    },
@@ -2900,7 +2900,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2914,17 +2914,17 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.0</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
        "      <td>NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2936,7 +2936,7 @@
        "1    VA  5.1     NaN  2013"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2954,7 +2954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 70,
    "metadata": {
     "collapsed": false
    },
@@ -2962,7 +2962,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2976,17 +2976,17 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.1</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
        "      <td>NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td>  6</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2998,7 +2998,7 @@
        "2    VA  5.2       6  2014"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3016,7 +3016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 71,
    "metadata": {
     "collapsed": false
    },
@@ -3024,7 +3024,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3038,69 +3038,69 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>  True</td>\n",
-       "      <td> False</td>\n",
-       "      <td> False</td>\n",
-       "      <td>  True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>  True</td>\n",
-       "      <td>  True</td>\n",
-       "      <td> False</td>\n",
-       "      <td>  True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>  True</td>\n",
-       "      <td>  True</td>\n",
-       "      <td>  True</td>\n",
-       "      <td>  True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>  True</td>\n",
-       "      <td> False</td>\n",
-       "      <td>  True</td>\n",
-       "      <td>  True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>  True</td>\n",
-       "      <td> False</td>\n",
-       "      <td>  True</td>\n",
-       "      <td>  True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> False</td>\n",
-       "      <td> False</td>\n",
-       "      <td> False</td>\n",
-       "      <td> False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> False</td>\n",
-       "      <td> False</td>\n",
-       "      <td> False</td>\n",
-       "      <td> False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   state    pop unempl   year\n",
-       "0   True  False  False   True\n",
-       "1   True   True  False   True\n",
-       "2   True   True   True   True\n",
-       "3   True  False   True   True\n",
-       "4   True  False   True   True\n",
-       "5  False  False  False  False\n",
-       "6  False  False  False  False"
+       "  state    pop unempl   year\n",
+       "0  True  False  False   True\n",
+       "1  True   True  False   True\n",
+       "2  True   True   True   True\n",
+       "3  True  False   True   True\n",
+       "4  True  False   True   True\n",
+       "5  True  False  False  False\n",
+       "6  True  False  False  False"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3118,7 +3118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 72,
    "metadata": {
     "collapsed": false
    },
@@ -3126,7 +3126,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3140,52 +3140,52 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3202,7 +3202,7 @@
        "6   NaN  NaN     NaN   NaN"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3220,7 +3220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 73,
    "metadata": {
     "collapsed": false
    },
@@ -3228,7 +3228,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3242,17 +3242,17 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3264,7 +3264,7 @@
        "3    MD  4.0       6  2014"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3282,98 +3282,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 74,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>state</th>\n",
-       "      <th>pop</th>\n",
-       "      <th>unempl</th>\n",
-       "      <th>year</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2012</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2013</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
-       "  state  pop  unempl  year\n",
-       "0    VA  5.0     NaN  2012\n",
-       "1    VA  5.1     NaN  2013\n",
-       "2    VA  5.2     6.0  2014\n",
-       "3    MD  4.0     6.0  2014\n",
-       "4    MD  4.1     6.1  2015\n",
-       "5   NaN  NaN     NaN   NaN\n",
-       "6   NaN  NaN     NaN   NaN"
+       "0    5.0\n",
+       "1    5.1\n",
+       "2    5.2\n",
+       "Name: pop, dtype: float64"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_6.ix[0:2, 'pop']\n",
-    "df_6"
+    "df_6.ix[0:2, 'pop']"
    ]
   },
   {
@@ -3385,7 +3314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 75,
    "metadata": {
     "collapsed": false
    },
@@ -3393,7 +3322,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3407,24 +3336,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3437,7 +3366,7 @@
        "4    MD  4.1     6.1  2015"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3462,7 +3391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 76,
    "metadata": {
     "collapsed": false
    },
@@ -3478,7 +3407,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3492,7 +3421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 77,
    "metadata": {
     "collapsed": false
    },
@@ -3508,7 +3437,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3522,7 +3451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 78,
    "metadata": {
     "collapsed": false
    },
@@ -3540,7 +3469,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3558,7 +3487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 79,
    "metadata": {
     "collapsed": false
    },
@@ -3576,7 +3505,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3594,7 +3523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 80,
    "metadata": {
     "collapsed": false
    },
@@ -3602,7 +3531,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3615,21 +3544,21 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.548814</td>\n",
-       "      <td> 0.715189</td>\n",
-       "      <td> 0.602763</td>\n",
+       "      <td>0.548814</td>\n",
+       "      <td>0.715189</td>\n",
+       "      <td>0.602763</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 0.544883</td>\n",
-       "      <td> 0.423655</td>\n",
-       "      <td> 0.645894</td>\n",
+       "      <td>0.544883</td>\n",
+       "      <td>0.423655</td>\n",
+       "      <td>0.645894</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 0.437587</td>\n",
-       "      <td> 0.891773</td>\n",
-       "      <td> 0.963663</td>\n",
+       "      <td>0.437587</td>\n",
+       "      <td>0.891773</td>\n",
+       "      <td>0.963663</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3642,7 +3571,7 @@
        "2  0.437587  0.891773  0.963663"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3656,7 +3585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 81,
    "metadata": {
     "collapsed": false
    },
@@ -3664,7 +3593,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3677,21 +3606,21 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.417022</td>\n",
-       "      <td> 0.720324</td>\n",
-       "      <td> 0.000114</td>\n",
+       "      <td>0.417022</td>\n",
+       "      <td>0.720324</td>\n",
+       "      <td>0.000114</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 0.302333</td>\n",
-       "      <td> 0.146756</td>\n",
-       "      <td> 0.092339</td>\n",
+       "      <td>0.302333</td>\n",
+       "      <td>0.146756</td>\n",
+       "      <td>0.092339</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 0.186260</td>\n",
-       "      <td> 0.345561</td>\n",
-       "      <td> 0.396767</td>\n",
+       "      <td>0.186260</td>\n",
+       "      <td>0.345561</td>\n",
+       "      <td>0.396767</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3704,7 +3633,7 @@
        "2  0.186260  0.345561  0.396767"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3718,7 +3647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 82,
    "metadata": {
     "collapsed": false
    },
@@ -3726,7 +3655,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3741,22 +3670,22 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>NaN</td>\n",
-       "      <td> 1.132211</td>\n",
-       "      <td> 1.323088</td>\n",
+       "      <td>1.132211</td>\n",
+       "      <td>1.323088</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>NaN</td>\n",
-       "      <td> 0.725987</td>\n",
-       "      <td> 0.792650</td>\n",
+       "      <td>0.725987</td>\n",
+       "      <td>0.792650</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>NaN</td>\n",
-       "      <td> 1.078033</td>\n",
-       "      <td> 1.309223</td>\n",
+       "      <td>1.078033</td>\n",
+       "      <td>1.309223</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -3770,7 +3699,7 @@
        "2 NaN  1.078033  1.309223 NaN"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3788,7 +3717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 83,
    "metadata": {
     "collapsed": false
    },
@@ -3796,7 +3725,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3810,24 +3739,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.548814</td>\n",
-       "      <td> 1.132211</td>\n",
-       "      <td> 1.323088</td>\n",
-       "      <td> 0.000114</td>\n",
+       "      <td>0.548814</td>\n",
+       "      <td>1.132211</td>\n",
+       "      <td>1.323088</td>\n",
+       "      <td>0.000114</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 0.544883</td>\n",
-       "      <td> 0.725987</td>\n",
-       "      <td> 0.792650</td>\n",
-       "      <td> 0.092339</td>\n",
+       "      <td>0.544883</td>\n",
+       "      <td>0.725987</td>\n",
+       "      <td>0.792650</td>\n",
+       "      <td>0.092339</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 0.437587</td>\n",
-       "      <td> 1.078033</td>\n",
-       "      <td> 1.309223</td>\n",
-       "      <td> 0.396767</td>\n",
+       "      <td>0.437587</td>\n",
+       "      <td>1.078033</td>\n",
+       "      <td>1.309223</td>\n",
+       "      <td>0.396767</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3840,7 +3769,7 @@
        "2  0.437587  1.078033  1.309223  0.396767"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3861,7 +3790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 84,
    "metadata": {
     "collapsed": false
    },
@@ -3869,7 +3798,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3883,24 +3812,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>-0.003930</td>\n",
        "      <td>-0.406224</td>\n",
        "      <td>-0.530438</td>\n",
-       "      <td> 0.092224</td>\n",
+       "      <td>0.092224</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>-0.111226</td>\n",
        "      <td>-0.054178</td>\n",
        "      <td>-0.013864</td>\n",
-       "      <td> 0.396653</td>\n",
+       "      <td>0.396653</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3913,7 +3842,7 @@
        "2 -0.111226 -0.054178 -0.013864  0.396653"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3933,7 +3862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 85,
    "metadata": {
     "collapsed": false
    },
@@ -3947,7 +3876,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3959,7 +3888,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 86,
    "metadata": {
     "collapsed": false
    },
@@ -3967,7 +3896,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3982,7 +3911,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>-1.000000</td>\n",
@@ -4015,7 +3944,7 @@
        "2 -0.111226 NaN NaN -0.603347 NaN"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4033,7 +3962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 87,
    "metadata": {
     "collapsed": false
    },
@@ -4041,7 +3970,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4055,24 +3984,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.548814</td>\n",
-       "      <td> 1.132211</td>\n",
-       "      <td> 1.323088</td>\n",
-       "      <td> 0.000114</td>\n",
+       "      <td>0.548814</td>\n",
+       "      <td>1.132211</td>\n",
+       "      <td>1.323088</td>\n",
+       "      <td>0.000114</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 0.544883</td>\n",
-       "      <td> 0.725987</td>\n",
-       "      <td> 0.792650</td>\n",
-       "      <td> 0.092339</td>\n",
+       "      <td>0.544883</td>\n",
+       "      <td>0.725987</td>\n",
+       "      <td>0.792650</td>\n",
+       "      <td>0.092339</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 0.437587</td>\n",
-       "      <td> 1.078033</td>\n",
-       "      <td> 1.309223</td>\n",
-       "      <td> 0.396767</td>\n",
+       "      <td>0.437587</td>\n",
+       "      <td>1.078033</td>\n",
+       "      <td>1.309223</td>\n",
+       "      <td>0.396767</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4085,7 +4014,7 @@
        "2  0.437587  1.078033  1.309223  0.396767"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4096,7 +4025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 88,
    "metadata": {
     "collapsed": false
    },
@@ -4110,7 +4039,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4122,7 +4051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 89,
    "metadata": {
     "collapsed": false
    },
@@ -4130,7 +4059,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4144,10 +4073,10 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> -99.451186</td>\n",
-       "      <td> -98.867789</td>\n",
-       "      <td> -98.676912</td>\n",
-       "      <td> -99.999886</td>\n",
+       "      <td>-99.451186</td>\n",
+       "      <td>-98.867789</td>\n",
+       "      <td>-98.676912</td>\n",
+       "      <td>-99.999886</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -4174,7 +4103,7 @@
        "2 -299.562413 -298.921967 -298.690777 -299.603233"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4199,7 +4128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 90,
    "metadata": {
     "collapsed": false
    },
@@ -4207,7 +4136,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4221,24 +4150,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 0.003930</td>\n",
-       "      <td> 0.406224</td>\n",
-       "      <td> 0.530438</td>\n",
-       "      <td> 0.092224</td>\n",
+       "      <td>0.003930</td>\n",
+       "      <td>0.406224</td>\n",
+       "      <td>0.530438</td>\n",
+       "      <td>0.092224</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 0.111226</td>\n",
-       "      <td> 0.054178</td>\n",
-       "      <td> 0.013864</td>\n",
-       "      <td> 0.396653</td>\n",
+       "      <td>0.111226</td>\n",
+       "      <td>0.054178</td>\n",
+       "      <td>0.013864</td>\n",
+       "      <td>0.396653</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4251,7 +4180,7 @@
        "2  0.111226  0.054178  0.013864  0.396653"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4270,7 +4199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 91,
    "metadata": {
     "collapsed": false
    },
@@ -4285,7 +4214,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4304,7 +4233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 92,
    "metadata": {
     "collapsed": false
    },
@@ -4318,7 +4247,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4336,7 +4265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 93,
    "metadata": {
     "collapsed": false
    },
@@ -4344,7 +4273,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4358,17 +4287,17 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>min</th>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
-       "      <td> 0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>max</th>\n",
-       "      <td> 0.111226</td>\n",
-       "      <td> 0.406224</td>\n",
-       "      <td> 0.530438</td>\n",
-       "      <td> 0.396653</td>\n",
+       "      <td>0.111226</td>\n",
+       "      <td>0.406224</td>\n",
+       "      <td>0.530438</td>\n",
+       "      <td>0.396653</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4380,7 +4309,7 @@
        "max  0.111226  0.406224  0.530438  0.396653"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4399,7 +4328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 94,
    "metadata": {
     "collapsed": false
    },
@@ -4407,7 +4336,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4421,24 +4350,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 0.00</td>\n",
-       "      <td> 0.00</td>\n",
-       "      <td> 0.00</td>\n",
-       "      <td> 0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 0.00</td>\n",
-       "      <td> 0.41</td>\n",
-       "      <td> 0.53</td>\n",
-       "      <td> 0.09</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.41</td>\n",
+       "      <td>0.53</td>\n",
+       "      <td>0.09</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 0.11</td>\n",
-       "      <td> 0.05</td>\n",
-       "      <td> 0.01</td>\n",
-       "      <td> 0.40</td>\n",
+       "      <td>0.11</td>\n",
+       "      <td>0.05</td>\n",
+       "      <td>0.01</td>\n",
+       "      <td>0.40</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4451,7 +4380,7 @@
        "2  0.11  0.05  0.01  0.40"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4470,7 +4399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 95,
    "metadata": {
     "collapsed": false
    },
@@ -4484,7 +4413,7 @@
        "Name: a, dtype: object"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4502,7 +4431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 96,
    "metadata": {
     "collapsed": false
    },
@@ -4517,7 +4446,7 @@
        "Name: foobarbazqux, dtype: float64"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4535,7 +4464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 97,
    "metadata": {
     "collapsed": false
    },
@@ -4550,7 +4479,7 @@
        "Name: foobarbazqux, dtype: float64"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4568,7 +4497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 134,
    "metadata": {
     "collapsed": false
    },
@@ -4583,18 +4512,18 @@
        "Name: foobarbazqux, dtype: float64"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ser_4.order()"
+    "ser_4.sort_values()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 99,
    "metadata": {
     "collapsed": false
    },
@@ -4602,7 +4531,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4616,24 +4545,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>three</th>\n",
-       "      <td> 0</td>\n",
-       "      <td> 1</td>\n",
-       "      <td>  2</td>\n",
-       "      <td>  3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>one</th>\n",
-       "      <td> 4</td>\n",
-       "      <td> 5</td>\n",
-       "      <td>  6</td>\n",
-       "      <td>  7</td>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>6</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>two</th>\n",
-       "      <td> 8</td>\n",
-       "      <td> 9</td>\n",
-       "      <td> 10</td>\n",
-       "      <td> 11</td>\n",
+       "      <td>8</td>\n",
+       "      <td>9</td>\n",
+       "      <td>10</td>\n",
+       "      <td>11</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4646,7 +4575,7 @@
        "two    8  9  10  11"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4667,7 +4596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 100,
    "metadata": {
     "collapsed": false
    },
@@ -4675,7 +4604,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4689,24 +4618,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>one</th>\n",
-       "      <td> 4</td>\n",
-       "      <td> 5</td>\n",
-       "      <td>  6</td>\n",
-       "      <td>  7</td>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>6</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>three</th>\n",
-       "      <td> 0</td>\n",
-       "      <td> 1</td>\n",
-       "      <td>  2</td>\n",
-       "      <td>  3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>two</th>\n",
-       "      <td> 8</td>\n",
-       "      <td> 9</td>\n",
-       "      <td> 10</td>\n",
-       "      <td> 11</td>\n",
+       "      <td>8</td>\n",
+       "      <td>9</td>\n",
+       "      <td>10</td>\n",
+       "      <td>11</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4719,7 +4648,7 @@
        "two    8  9  10  11"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4737,7 +4666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 101,
    "metadata": {
     "collapsed": false
    },
@@ -4745,7 +4674,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4759,24 +4688,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>three</th>\n",
-       "      <td>  3</td>\n",
-       "      <td> 0</td>\n",
-       "      <td>  2</td>\n",
-       "      <td> 1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>one</th>\n",
-       "      <td>  7</td>\n",
-       "      <td> 4</td>\n",
-       "      <td>  6</td>\n",
-       "      <td> 5</td>\n",
+       "      <td>7</td>\n",
+       "      <td>4</td>\n",
+       "      <td>6</td>\n",
+       "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>two</th>\n",
-       "      <td> 11</td>\n",
-       "      <td> 8</td>\n",
-       "      <td> 10</td>\n",
-       "      <td> 9</td>\n",
+       "      <td>11</td>\n",
+       "      <td>8</td>\n",
+       "      <td>10</td>\n",
+       "      <td>9</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4789,7 +4718,7 @@
        "two    11  8  10  9"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4807,7 +4736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 133,
    "metadata": {
     "collapsed": false
    },
@@ -4815,7 +4744,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4829,24 +4758,24 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>three</th>\n",
-       "      <td> 0</td>\n",
-       "      <td> 1</td>\n",
-       "      <td>  2</td>\n",
-       "      <td>  3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>one</th>\n",
-       "      <td> 4</td>\n",
-       "      <td> 5</td>\n",
-       "      <td>  6</td>\n",
-       "      <td>  7</td>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>6</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>two</th>\n",
-       "      <td> 8</td>\n",
-       "      <td> 9</td>\n",
-       "      <td> 10</td>\n",
-       "      <td> 11</td>\n",
+       "      <td>8</td>\n",
+       "      <td>9</td>\n",
+       "      <td>10</td>\n",
+       "      <td>11</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4859,13 +4788,13 @@
        "two    8  9  10  11"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_12.sort_index(by=['d', 'c'])"
+    "df_12.sort_values(by=['d', 'c'])"
    ]
   },
   {
@@ -4877,7 +4806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 132,
    "metadata": {
     "collapsed": false
    },
@@ -4896,20 +4825,20 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "ser_11 = Series([7, -5, 7, 4, 2, 0, 4, 7])\n",
-    "ser_11 = ser_11.order()\n",
+    "ser_11 = ser_11.sort_values()\n",
     "ser_11"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 104,
    "metadata": {
     "collapsed": false
    },
@@ -4928,7 +4857,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4946,7 +4875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 105,
    "metadata": {
     "collapsed": false
    },
@@ -4965,7 +4894,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4983,7 +4912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 106,
    "metadata": {
     "collapsed": false
    },
@@ -5002,7 +4931,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5020,7 +4949,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 107,
    "metadata": {
     "collapsed": false
    },
@@ -5028,7 +4957,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5043,49 +4972,49 @@
        "      <th>0</th>\n",
        "      <td>-5</td>\n",
        "      <td>-1</td>\n",
-       "      <td> 7</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 4</td>\n",
-       "      <td> 2</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2</td>\n",
        "      <td>-5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 2</td>\n",
-       "      <td> 3</td>\n",
-       "      <td> 7</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 0</td>\n",
-       "      <td> 0</td>\n",
-       "      <td> 4</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4</td>\n",
-       "      <td> 5</td>\n",
-       "      <td> 2</td>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> 7</td>\n",
-       "      <td> 9</td>\n",
-       "      <td> 0</td>\n",
+       "      <td>7</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> 7</td>\n",
-       "      <td> 9</td>\n",
-       "      <td> 4</td>\n",
+       "      <td>7</td>\n",
+       "      <td>9</td>\n",
+       "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td> 8</td>\n",
-       "      <td> 5</td>\n",
-       "      <td> 7</td>\n",
+       "      <td>8</td>\n",
+       "      <td>5</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5103,7 +5032,7 @@
        "7    8    5    7"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5124,7 +5053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 108,
    "metadata": {
     "collapsed": false
    },
@@ -5132,7 +5061,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5145,51 +5074,51 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 1.0</td>\n",
-       "      <td> 1.0</td>\n",
-       "      <td> 7.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>7.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 4.5</td>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> 1.0</td>\n",
+       "      <td>4.5</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 7.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>7.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 4.5</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>4.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4.5</td>\n",
-       "      <td> 5.5</td>\n",
-       "      <td> 3.0</td>\n",
+       "      <td>4.5</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>3.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> 6.5</td>\n",
-       "      <td> 7.5</td>\n",
-       "      <td> 2.0</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>7.5</td>\n",
+       "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> 6.5</td>\n",
-       "      <td> 7.5</td>\n",
-       "      <td> 4.5</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>7.5</td>\n",
+       "      <td>4.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td> 8.0</td>\n",
-       "      <td> 5.5</td>\n",
-       "      <td> 7.0</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>7.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5207,7 +5136,7 @@
        "7  8.0  5.5  7.0"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5225,7 +5154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 109,
    "metadata": {
     "collapsed": false
    },
@@ -5233,7 +5162,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5246,51 +5175,51 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 1.0</td>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 3</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 1</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 1.0</td>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 3</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 1.5</td>\n",
-       "      <td> 1.5</td>\n",
-       "      <td> 3</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> 1</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> 1</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> 2.0</td>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> 1</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> 1.0</td>\n",
-       "      <td> 2</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5308,7 +5237,7 @@
        "7  3.0  1.0    2"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5333,7 +5262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 110,
    "metadata": {
     "collapsed": false
    },
@@ -5349,7 +5278,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5361,7 +5290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 111,
    "metadata": {
     "collapsed": false
    },
@@ -5372,7 +5301,7 @@
        "False"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5390,7 +5319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 112,
    "metadata": {
     "collapsed": false
    },
@@ -5403,7 +5332,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5421,7 +5350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 113,
    "metadata": {
     "collapsed": false
    },
@@ -5429,7 +5358,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5444,37 +5373,37 @@
        "    <tr>\n",
        "      <th>foo</th>\n",
        "      <td>-2.363469</td>\n",
-       "      <td> 1.135345</td>\n",
+       "      <td>1.135345</td>\n",
        "      <td>-1.017014</td>\n",
-       "      <td> 0.637362</td>\n",
+       "      <td>0.637362</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>foo</th>\n",
        "      <td>-0.859907</td>\n",
-       "      <td> 1.772608</td>\n",
+       "      <td>1.772608</td>\n",
        "      <td>-1.110363</td>\n",
-       "      <td> 0.181214</td>\n",
+       "      <td>0.181214</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>bar</th>\n",
-       "      <td> 0.564345</td>\n",
+       "      <td>0.564345</td>\n",
        "      <td>-0.566510</td>\n",
-       "      <td> 0.729976</td>\n",
-       "      <td> 0.372994</td>\n",
+       "      <td>0.729976</td>\n",
+       "      <td>0.372994</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>bar</th>\n",
-       "      <td> 0.533811</td>\n",
+       "      <td>0.533811</td>\n",
        "      <td>-0.091973</td>\n",
-       "      <td> 1.913820</td>\n",
-       "      <td> 0.330797</td>\n",
+       "      <td>1.913820</td>\n",
+       "      <td>0.330797</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>baz</th>\n",
-       "      <td> 1.141943</td>\n",
+       "      <td>1.141943</td>\n",
        "      <td>-1.129595</td>\n",
        "      <td>-0.850052</td>\n",
-       "      <td> 0.960820</td>\n",
+       "      <td>0.960820</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5489,7 +5418,7 @@
        "baz  1.141943 -1.129595 -0.850052  0.960820"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5502,7 +5431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 114,
    "metadata": {
     "collapsed": false
    },
@@ -5510,7 +5439,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5524,17 +5453,17 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>bar</th>\n",
-       "      <td> 0.564345</td>\n",
+       "      <td>0.564345</td>\n",
        "      <td>-0.566510</td>\n",
-       "      <td> 0.729976</td>\n",
-       "      <td> 0.372994</td>\n",
+       "      <td>0.729976</td>\n",
+       "      <td>0.372994</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>bar</th>\n",
-       "      <td> 0.533811</td>\n",
+       "      <td>0.533811</td>\n",
        "      <td>-0.091973</td>\n",
-       "      <td> 1.913820</td>\n",
-       "      <td> 0.330797</td>\n",
+       "      <td>1.913820</td>\n",
+       "      <td>0.330797</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5546,7 +5475,7 @@
        "bar  0.533811 -0.091973  1.913820  0.330797"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5571,7 +5500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 115,
    "metadata": {
     "collapsed": false
    },
@@ -5579,7 +5508,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5593,52 +5522,52 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>  VA</td>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>  MD</td>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td>  NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5655,7 +5584,7 @@
        "6   NaN  NaN     NaN   NaN"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5666,7 +5595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 116,
    "metadata": {
     "collapsed": false
    },
@@ -5680,7 +5609,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5698,7 +5627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 117,
    "metadata": {
     "collapsed": false
    },
@@ -5711,12 +5640,12 @@
        "2    2025.2\n",
        "3    2024.0\n",
        "4    2025.2\n",
-       "5       NaN\n",
-       "6       NaN\n",
+       "5       0.0\n",
+       "6       0.0\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5734,7 +5663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 118,
    "metadata": {
     "collapsed": false
    },
@@ -5752,7 +5681,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5773,7 +5702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 119,
    "metadata": {
     "collapsed": false
    },
@@ -5792,7 +5721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 120,
    "metadata": {
     "collapsed": false
    },
@@ -5800,7 +5729,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5813,33 +5742,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> VA</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>VA</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> MD</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5854,7 +5783,7 @@
        "4         4.1    MD  2015"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 120,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5883,7 +5812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 121,
    "metadata": {
     "collapsed": false
    },
@@ -5891,7 +5820,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5904,33 +5833,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 4.0</td>\n",
-       "      <td>       MD</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td>       MD</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>MD</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5945,7 +5874,7 @@
        "4         4.1        MD  2015"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5964,7 +5893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 122,
    "metadata": {
     "collapsed": false
    },
@@ -5972,7 +5901,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -5985,33 +5914,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> MARYLAND</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>MARYLAND</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> MARYLAND</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>MARYLAND</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -6026,7 +5955,7 @@
        "4         4.1  MARYLAND  2015"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6052,7 +5981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 123,
    "metadata": {
     "collapsed": false
    },
@@ -6060,7 +5989,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -6072,28 +6001,28 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> MARYLAND</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>MARYLAND</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> MARYLAND</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>MARYLAND</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -6108,7 +6037,7 @@
        "4  MARYLAND  2015"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6134,7 +6063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 124,
    "metadata": {
     "collapsed": false
    },
@@ -6142,7 +6071,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -6155,33 +6084,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 6.0</td>\n",
-       "      <td> NY</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 6.1</td>\n",
-       "      <td> NY</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 6.2</td>\n",
-       "      <td> NY</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>6.2</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 3.0</td>\n",
-       "      <td> FL</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>FL</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 3.1</td>\n",
-       "      <td> FL</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>FL</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -6196,7 +6125,7 @@
        "4         3.1    FL  2015"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6211,7 +6140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 125,
    "metadata": {
     "collapsed": false
    },
@@ -6219,7 +6148,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -6232,63 +6161,63 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 5.0</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 5.1</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 5.2</td>\n",
-       "      <td> VIRGINIA</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>5.2</td>\n",
+       "      <td>VIRGINIA</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 4.0</td>\n",
-       "      <td> MARYLAND</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>MARYLAND</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 4.1</td>\n",
-       "      <td> MARYLAND</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>4.1</td>\n",
+       "      <td>MARYLAND</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 6.0</td>\n",
-       "      <td>       NY</td>\n",
-       "      <td> 2012</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>2012</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 6.1</td>\n",
-       "      <td>       NY</td>\n",
-       "      <td> 2013</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 6.2</td>\n",
-       "      <td>       NY</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>6.2</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 3.0</td>\n",
-       "      <td>       FL</td>\n",
-       "      <td> 2014</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>FL</td>\n",
+       "      <td>2014</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td> 3.1</td>\n",
-       "      <td>       FL</td>\n",
-       "      <td> 2015</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>FL</td>\n",
+       "      <td>2015</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -6308,7 +6237,7 @@
        "4         3.1        FL  2015"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6329,7 +6258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 126,
    "metadata": {
     "collapsed": false
    },
@@ -6355,7 +6284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 127,
    "metadata": {
     "collapsed": false
    },
@@ -6373,7 +6302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 128,
    "metadata": {
     "collapsed": false
    },
@@ -6381,7 +6310,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -6397,75 +6326,75 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>count</th>\n",
-       "      <td> 116.000000</td>\n",
-       "      <td> 146.000000</td>\n",
-       "      <td> 153.000000</td>\n",
-       "      <td> 153.000000</td>\n",
-       "      <td> 153.000000</td>\n",
-       "      <td> 153.000000</td>\n",
+       "      <td>116.000000</td>\n",
+       "      <td>146.000000</td>\n",
+       "      <td>153.000000</td>\n",
+       "      <td>153.000000</td>\n",
+       "      <td>153.000000</td>\n",
+       "      <td>153.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>mean</th>\n",
-       "      <td>  42.129310</td>\n",
-       "      <td> 185.931507</td>\n",
-       "      <td>   9.957516</td>\n",
-       "      <td>  77.882353</td>\n",
-       "      <td>   6.993464</td>\n",
-       "      <td>  15.803922</td>\n",
+       "      <td>42.129310</td>\n",
+       "      <td>185.931507</td>\n",
+       "      <td>9.957516</td>\n",
+       "      <td>77.882353</td>\n",
+       "      <td>6.993464</td>\n",
+       "      <td>15.803922</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>std</th>\n",
-       "      <td>  32.987885</td>\n",
-       "      <td>  90.058422</td>\n",
-       "      <td>   3.523001</td>\n",
-       "      <td>   9.465270</td>\n",
-       "      <td>   1.416522</td>\n",
-       "      <td>   8.864520</td>\n",
+       "      <td>32.987885</td>\n",
+       "      <td>90.058422</td>\n",
+       "      <td>3.523001</td>\n",
+       "      <td>9.465270</td>\n",
+       "      <td>1.416522</td>\n",
+       "      <td>8.864520</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>min</th>\n",
-       "      <td>   1.000000</td>\n",
-       "      <td>   7.000000</td>\n",
-       "      <td>   1.700000</td>\n",
-       "      <td>  56.000000</td>\n",
-       "      <td>   5.000000</td>\n",
-       "      <td>   1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>7.000000</td>\n",
+       "      <td>1.700000</td>\n",
+       "      <td>56.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25%</th>\n",
-       "      <td>  18.000000</td>\n",
-       "      <td> 115.750000</td>\n",
-       "      <td>   7.400000</td>\n",
-       "      <td>  72.000000</td>\n",
-       "      <td>   6.000000</td>\n",
-       "      <td>   8.000000</td>\n",
+       "      <td>18.000000</td>\n",
+       "      <td>115.750000</td>\n",
+       "      <td>7.400000</td>\n",
+       "      <td>72.000000</td>\n",
+       "      <td>6.000000</td>\n",
+       "      <td>8.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>50%</th>\n",
-       "      <td>  31.500000</td>\n",
-       "      <td> 205.000000</td>\n",
-       "      <td>   9.700000</td>\n",
-       "      <td>  79.000000</td>\n",
-       "      <td>   7.000000</td>\n",
-       "      <td>  16.000000</td>\n",
+       "      <td>31.500000</td>\n",
+       "      <td>205.000000</td>\n",
+       "      <td>9.700000</td>\n",
+       "      <td>79.000000</td>\n",
+       "      <td>7.000000</td>\n",
+       "      <td>16.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>75%</th>\n",
-       "      <td>  63.250000</td>\n",
-       "      <td> 258.750000</td>\n",
-       "      <td>  11.500000</td>\n",
-       "      <td>  85.000000</td>\n",
-       "      <td>   8.000000</td>\n",
-       "      <td>  23.000000</td>\n",
+       "      <td>63.250000</td>\n",
+       "      <td>258.750000</td>\n",
+       "      <td>11.500000</td>\n",
+       "      <td>85.000000</td>\n",
+       "      <td>8.000000</td>\n",
+       "      <td>23.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>max</th>\n",
-       "      <td> 168.000000</td>\n",
-       "      <td> 334.000000</td>\n",
-       "      <td>  20.700000</td>\n",
-       "      <td>  97.000000</td>\n",
-       "      <td>   9.000000</td>\n",
-       "      <td>  31.000000</td>\n",
+       "      <td>168.000000</td>\n",
+       "      <td>334.000000</td>\n",
+       "      <td>20.700000</td>\n",
+       "      <td>97.000000</td>\n",
+       "      <td>9.000000</td>\n",
+       "      <td>31.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -6483,7 +6412,7 @@
        "max    168.000000  334.000000   20.700000   97.000000    9.000000   31.000000"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 128,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6501,7 +6430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 129,
    "metadata": {
     "collapsed": false
    },
@@ -6509,7 +6438,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -6525,48 +6454,48 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td> 41</td>\n",
-       "      <td> 190</td>\n",
-       "      <td>  7.4</td>\n",
-       "      <td> 67</td>\n",
-       "      <td> 5</td>\n",
-       "      <td> 1</td>\n",
+       "      <td>41</td>\n",
+       "      <td>190</td>\n",
+       "      <td>7.4</td>\n",
+       "      <td>67</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td> 36</td>\n",
-       "      <td> 118</td>\n",
-       "      <td>  8.0</td>\n",
-       "      <td> 72</td>\n",
-       "      <td> 5</td>\n",
-       "      <td> 2</td>\n",
+       "      <td>36</td>\n",
+       "      <td>118</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>72</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td> 12</td>\n",
-       "      <td> 149</td>\n",
-       "      <td> 12.6</td>\n",
-       "      <td> 74</td>\n",
-       "      <td> 5</td>\n",
-       "      <td> 3</td>\n",
+       "      <td>12</td>\n",
+       "      <td>149</td>\n",
+       "      <td>12.6</td>\n",
+       "      <td>74</td>\n",
+       "      <td>5</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td> 18</td>\n",
-       "      <td> 313</td>\n",
-       "      <td> 11.5</td>\n",
-       "      <td> 62</td>\n",
-       "      <td> 5</td>\n",
-       "      <td> 4</td>\n",
+       "      <td>18</td>\n",
+       "      <td>313</td>\n",
+       "      <td>11.5</td>\n",
+       "      <td>62</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>NaN</td>\n",
-       "      <td> NaN</td>\n",
-       "      <td> 14.3</td>\n",
-       "      <td> 56</td>\n",
-       "      <td> 5</td>\n",
-       "      <td> 5</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>14.3</td>\n",
+       "      <td>56</td>\n",
+       "      <td>5</td>\n",
+       "      <td>5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -6581,7 +6510,7 @@
        "4    NaN      NaN  14.3    56      5    5"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6606,7 +6535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 130,
    "metadata": {
     "collapsed": false
    },
@@ -6627,7 +6556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 131,
    "metadata": {
     "collapsed": false
    },
@@ -6636,9 +6565,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "total 16\r\n",
-      "-rw-r--r--@ 1 dmartin  1443163707  2902 Dec 26  2012 ozone.csv\r\n",
-      "-rw-r--r--  1 dmartin  1443163707  3324 Feb 14 06:40 ozone_copy.csv\r\n"
+      "total 1016\r\n",
+      "-rw-r--r--   1 gam  staff  437903 Feb 15 07:16 churn.csv\r\n",
+      "-rwxr-xr-x   1 gam  staff   72050 Feb 15 07:16 \u001b[31mconfusion_matrix.png\u001b[m\u001b[m\r\n",
+      "-rw-r--r--   1 gam  staff    2902 Feb 15 07:16 ozone.csv\r\n",
+      "-rw-r--r--   1 gam  staff    3324 Mar  4 17:53 ozone_copy.csv\r\n",
+      "drwxr-xr-x  10 gam  staff     340 Feb 15 07:16 \u001b[1m\u001b[36mtitanic\u001b[m\u001b[m\r\n"
      ]
     }
    ],
@@ -6649,21 +6581,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Slice of rows from a specific column of a DataFrame shows df_6 instead of the slice output. 
2. Replaced order() and sort_index(by= which are deprecated with sort_values() 

