### PR TITLE
Fix incorrect return type comment for dict.values()

### DIFF
--- a/python-data/structs.ipynb
+++ b/python-data/structs.ipynb
@@ -1007,7 +1007,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Get the list of values in no particular order (although values() outputs the keys in the same order).  In Python 3, keys() returns an iterator instead of a list."
+    "Get the list of values in no particular order (although values() outputs the keys in the same order).  In Python 3, values() returns an iterator instead of a list."
    ]
   },
   {

--- a/python-data/structs.ipynb
+++ b/python-data/structs.ipynb
@@ -1007,7 +1007,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Get the list of values in no particular order (although values() outputs the keys in the same order).  In Python 3, values() returns an iterator instead of a list."
+    "Get the list of values in no particular order (although values() outputs the keys in the same order).  In Python 3, values() returns a [view object](https://docs.python.org/3/library/stdtypes.html?highlight=dictview#dictionary-view-objects) instead of a list."
    ]
   },
   {


### PR DESCRIPTION
i think you meant values() not keys()